### PR TITLE
fix: Handle non-existent directories in audit logger

### DIFF
--- a/profiles/account/scripts/audit_logger.py
+++ b/profiles/account/scripts/audit_logger.py
@@ -33,7 +33,16 @@ def run_command(cmd, cwd=None, timeout=5):
 def get_git_info(cwd):
     """Get Git repository information"""
     git_info = {}
-    
+
+    # Check if directory exists
+    if not os.path.exists(cwd):
+        return {
+            'repo': 'unknown',
+            'branch': 'unknown',
+            'commit': 'unknown',
+            'dirty': False
+        }
+
     # Repository name
     repo_name = run_command("basename `git rev-parse --show-toplevel`", cwd)
     git_info['repo'] = repo_name or "unknown"
@@ -107,10 +116,20 @@ def main():
     try:
         # Read JSON input from stdin
         input_data = json.load(sys.stdin)
-        
+
         # Get current working directory
-        cwd = input_data.get('cwd', os.getcwd())
-        
+        cwd = input_data.get('cwd')
+        if not cwd:
+            try:
+                cwd = os.getcwd()
+            except OSError:
+                # Current directory doesn't exist
+                cwd = os.path.expanduser("~")
+
+        # Validate and fallback to home if cwd doesn't exist
+        if not os.path.exists(cwd):
+            cwd = os.path.expanduser("~")
+
         # Collect information
         git_info = get_git_info(cwd)
         system_info = get_system_info()


### PR DESCRIPTION
## Summary
- Fixed audit_logger.py failures when working directory is removed (e.g., during git worktree operations)
- Added robust directory existence checking and fallback mechanisms
- Prevents hook execution errors that block subsequent Bash commands

## Problem
When Claude Code operates in a git worktree that gets removed, the audit logger hook fails with:
- `fatal: Unable to read current working directory: No such file or directory`
- `spawn /bin/sh ENOENT` errors
- All subsequent Bash commands fail due to hook failure

## Solution
1. **Directory Existence Check**: Added validation in `get_git_info()` to return safe defaults when directory doesn't exist
2. **OSError Handling**: Wrapped `os.getcwd()` in try/catch to handle deleted directories
3. **Fallback Logic**: Falls back to home directory when working directory is unavailable

## Test Plan
- [x] Tested with normal operations
- [x] Tested after worktree removal
- [x] Hook executes without errors in both scenarios
- [x] Bash commands continue to work after directory removal

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 작업 디렉터리가 없거나 접근 불가한 경우 홈 디렉터리로 자동 대체해 실행 실패를 방지합니다.
  * Git 저장소/브랜치/커밋 정보를 확인할 수 없을 때 ‘unknown’으로 처리하여 불필요한 오류를 줄였습니다.
  * 예외 상황의 경로 처리 로직을 강화해 컨테이너·배치·임시 경로 등 다양한 환경에서 로깅이 더욱 안정적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->