### PR TITLE
[Phase 1] Worktree Skill 전환

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -285,7 +285,7 @@ install_config() {
             log "Installing skills..."
             cp -r "$PROFILE_DIR/skills" "$CLAUDE_CONFIG_DIR/"
         else
-            debug "Skills directory not found (optional)"
+            info "Skills directory not found (optional)"
         fi
         
         if [ -f "$PROFILE_DIR/CLAUDE.md" ]; then
@@ -405,7 +405,7 @@ verify_installation() {
     if [ -d "$CLAUDE_CONFIG_DIR/skills" ]; then
         info "✓ Skills installed ($(find "$CLAUDE_CONFIG_DIR/skills" -name "SKILL.md" | wc -l) skills)"
     else
-        debug "Skills not installed (optional)"
+        info "Skills not installed (optional)"
     fi
 
     if [ -f "$CLAUDE_CONFIG_DIR/CLAUDE.md" ]; then

--- a/profiles/account/agents/worktree-coordinator.md
+++ b/profiles/account/agents/worktree-coordinator.md
@@ -7,9 +7,10 @@ deprecated: true
 deprecated-by: skills/worktree/SKILL.md
 ---
 
-> **DEPRECATED**: This agent has been migrated to `skills/worktree/SKILL.md`.
+> **DEPRECATED** (v2.0 removal planned)
+>
+> This agent has been migrated to `skills/worktree/SKILL.md`.
 > Use the skill-based workflow instead: `/worktree:plan`, `/worktree:distribute`, etc.
-> This file will be removed in a future version.
 
 # Worktree Coordination Agent
 

--- a/profiles/account/commands/worktree/distribute.md
+++ b/profiles/account/commands/worktree/distribute.md
@@ -4,7 +4,7 @@ deprecated: true
 deprecated-by: skills/worktree/workflows/distribute.md
 ---
 
-> **DEPRECATED**: Migrated to `skills/worktree/workflows/distribute.md`
+> **DEPRECATED** (v2.0 removal planned): Migrated to `skills/worktree/workflows/distribute.md`
 
 # Worktree Distribution
 

--- a/profiles/account/commands/worktree/plan.md
+++ b/profiles/account/commands/worktree/plan.md
@@ -4,7 +4,7 @@ deprecated: true
 deprecated-by: skills/worktree/workflows/plan.md
 ---
 
-> **DEPRECATED**: Migrated to `skills/worktree/workflows/plan.md`
+> **DEPRECATED** (v2.0 removal planned): Migrated to `skills/worktree/workflows/plan.md`
 
 # Worktree Planning
 

--- a/profiles/account/commands/worktree/status.md
+++ b/profiles/account/commands/worktree/status.md
@@ -4,7 +4,7 @@ deprecated: true
 deprecated-by: skills/worktree/workflows/status.md
 ---
 
-> **DEPRECATED**: Migrated to `skills/worktree/workflows/status.md`
+> **DEPRECATED** (v2.0 removal planned): Migrated to `skills/worktree/workflows/status.md`
 
 # Worktree Status
 

--- a/profiles/account/commands/worktree/sync.md
+++ b/profiles/account/commands/worktree/sync.md
@@ -4,7 +4,7 @@ deprecated: true
 deprecated-by: skills/worktree/workflows/sync.md
 ---
 
-> **DEPRECATED**: Migrated to `skills/worktree/workflows/sync.md`
+> **DEPRECATED** (v2.0 removal planned): Migrated to `skills/worktree/workflows/sync.md`
 
 # Worktree Synchronization
 

--- a/profiles/account/skills/worktree/SKILL.md
+++ b/profiles/account/skills/worktree/SKILL.md
@@ -7,6 +7,7 @@ description: |
   Triggers: "worktree", "parallel work", "multiple features", "병렬 작업",
   "동시에 작업", "워크트리"
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
+model: sonnet
 ---
 
 # Worktree Management Skill
@@ -50,7 +51,7 @@ Git worktrees를 활용해 여러 기능을 동시에 개발할 수 있게 해�
 ## Workflow Sequence
 
 ```text
-/worktree:plan → PLAN.md 생성 → /worktree:distribute → 병렬 실행 → /worktree:status
+/worktree:plan → PLAN.md 생성 → /worktree:distribute → 병렬 실행 → /worktree:sync → /worktree:status
 ```
 
 ## PLAN.md Format
@@ -143,3 +144,9 @@ Common issues and solutions:
 - 각 병렬 작업에 대한 명확한 문서
 - 효율적인 리소스 공유 (symlinks 작동)
 - 완료 후 원활한 병합 프로세스
+
+## Resources
+
+상세 가이드 및 참조 문서:
+- `context/worktree-guide.md` - Git worktree 명령어 및 트러블슈팅 가이드
+- `scripts/worktree-manager.sh` - Worktree 자동화 스크립트

--- a/profiles/account/skills/worktree/context/worktree-guide.md
+++ b/profiles/account/skills/worktree/context/worktree-guide.md
@@ -214,4 +214,3 @@ jobs:
 ## References
 
 - [Git Worktree Documentation](https://git-scm.com/docs/git-worktree)
-- [Pro Git - Git Worktree](https://git-scm.com/book/en/v2/Git-Tools-Working-with-Worktrees)

--- a/profiles/account/skills/worktree/workflows/distribute.md
+++ b/profiles/account/skills/worktree/workflows/distribute.md
@@ -30,7 +30,7 @@ Parse `.worktrees/PLAN.md` and create isolated worktrees for parallel developmen
    - Copy environment files (.env, package.json, lock files)
    - Create node_modules symlinks for efficiency
    - Link Python venv if present
-   - Copy 17+ config file types automatically
+   - Copy 25+ config file types automatically
 
 5. **Generate Documentation**:
    - Create task instruction at `.worktrees/tasks/[task-name].md`
@@ -88,25 +88,25 @@ Creates for each task:
 
 Common issues and solutions:
 - **Branch exists**: Check and clean existing branches
-- **PLAN.md missing**: Create template or use `/worktree-plan`
+- **PLAN.md missing**: Create template or use `/worktree:plan`
 - **Permission denied**: Check script execution permissions
 - **Disk space**: Verify sufficient space before distribution
 
 ## Integration Points
 
-- Use after `/worktree-plan` for automatic planning
-- Monitor with `/worktree-status`
-- Synchronize with `/worktree-sync`
+- Use after `/worktree:plan` for automatic planning
+- Monitor with `/worktree:status`
+- Synchronize with `/worktree:sync`
 - Clean up with `git worktree remove`
 
 ## Example Workflow
 
 ```bash
 # Generate plan (if not exists)
-/worktree-plan "implement auth, payment, and search"
+/worktree:plan "implement auth, payment, and search"
 
 # Distribute tasks
-/worktree-distribute
+/worktree:distribute
 
 # Work in parallel (different terminals)
 cd .worktrees/auth && claude

--- a/profiles/account/skills/worktree/workflows/plan.md
+++ b/profiles/account/skills/worktree/workflows/plan.md
@@ -32,19 +32,19 @@ Leverage plan-agent to analyze complex requirements, identify parallelizable wor
 4. **Prepare for Distribution**:
    - Validate branch name availability
    - Check for existing worktrees
-   - Ready for `/worktree-distribute`
+   - Ready for `/worktree:distribute`
 
 ## Examples
 
 ```bash
 # Example 1: E-commerce site core features
-/worktree-plan "Add authentication, payment, and search features to e-commerce site"
+/worktree:plan "Add authentication, payment, and search features to e-commerce site"
 
 # Example 2: Large-scale refactoring
-/worktree-plan "Migrate from React 16 to 18 while introducing TypeScript"
+/worktree:plan "Migrate from React 16 to 18 while introducing TypeScript"
 
 # Example 3: Bug fixes
-/worktree-plan "Fix bugs found in login, payment, and search"
+/worktree:plan "Fix bugs found in login, payment, and search"
 ```
 
 ## Integration with plan-agent
@@ -87,7 +87,7 @@ search: Elasticsearch search feature (estimated: 2h)
 ## Workflow Sequence
 
 ```text
-/worktree-plan → plan-agent analysis → PLAN.md generation → /worktree-distribute → Parallel execution
+/worktree:plan → plan-agent analysis → PLAN.md generation → /worktree:distribute → Parallel execution
 ```
 
 ## Success Indicators
@@ -115,8 +115,8 @@ search: Elasticsearch search feature (estimated: 2h)
 ## Related Commands
 
 - `/plan` - General strategic planning
-- `/worktree-distribute` - Execute task distribution
-- `/worktree-status` - Monitor progress
-- `/worktree-sync` - Synchronize environments
+- `/worktree:distribute` - Execute task distribution
+- `/worktree:status` - Monitor progress
+- `/worktree:sync` - Synchronize environments
 
 Execute plan-agent now to analyze and generate parallel task plan.

--- a/profiles/account/skills/worktree/workflows/status.md
+++ b/profiles/account/skills/worktree/workflows/status.md
@@ -70,17 +70,9 @@ Git Worktree Summary:
 
 ## Integration Points
 
-- After `/worktree-distribute` to verify setup
+- After `/worktree:distribute` to verify setup
 - Before merging to check completion
 - During work to monitor progress
-- With `/worktree-sync` to identify sync needs
-
-## Advanced Options
-
-Future enhancements could include:
-- Filter by status (complete/in-progress)
-- Show test results per worktree
-- Display merge conflict warnings
-- Track time spent per task
+- With `/worktree:sync` to identify sync needs
 
 Execute status check now using `scripts/worktree-manager.sh status`.

--- a/profiles/account/skills/worktree/workflows/sync.md
+++ b/profiles/account/skills/worktree/workflows/sync.md
@@ -33,15 +33,10 @@ Keep environment files, dependencies, and configurations consistent across all p
 
 ## Files Synchronized
 
-### High Priority (Always Sync)
-- `.env`, `.env.local`, `.env.development`
-- Security certificates and keys
-- Shared configuration files
-
-### Medium Priority (Sync if Changed)
-- `package.json` (warn about npm install)
-- `requirements.txt` (warn about pip install)
-- Config files (tsconfig, eslint, prettier)
+Currently syncs the following core files:
+- `.env` - Environment variables
+- `.env.local` - Local environment overrides
+- `package.json` - Node.js dependencies (warn about npm install)
 
 ### Preserved (Never Overwrite)
 - Source code files
@@ -83,13 +78,5 @@ When conflicts detected:
 - Before starting work in worktree
 - After pulling updates from remote
 - Part of regular maintenance workflow
-
-## Advanced Features
-
-Future enhancements:
-- Two-way sync from worktrees to main
-- Automatic dependency installation
-- Config validation after sync
-- Sync history tracking
 
 Execute synchronization now using `scripts/worktree-manager.sh sync`.


### PR DESCRIPTION
## Summary

Skills 체계 검증을 위한 첫 번째 전환입니다. 기존 worktree 관련 agent와 commands를 하나의 skill로 통합합니다.

Closes #25

## Changes

### New Skill Structure
```
profiles/account/skills/worktree/
├── SKILL.md                       # worktree-coordinator 변환
├── workflows/
│   ├── plan.md
│   ├── distribute.md
│   ├── status.md
│   └── sync.md
└── context/
    └── worktree-guide.md
```

### Commits
1. **feat(skills): add worktree SKILL.md** - Agent를 Skills 형식으로 변환
2. **feat(skills): add worktree workflows** - 기존 commands를 workflows로 복사
3. **docs(skills): add worktree context guide** - 종합 가이드 문서 추가
4. **chore: add deprecation notices** - 기존 파일에 deprecated 표시
5. **feat(install): add skills directory support** - install.sh 업데이트

### Backward Compatibility
- 기존 `/worktree:*` 명령어는 그대로 동작
- 기존 agent/commands는 deprecated 표시만 추가 (삭제 안함)
- install.sh가 skills 디렉토리도 복사

## Test Plan

- [ ] 새 skills 구조로 `/worktree:plan` 테스트
- [ ] 새 skills 구조로 `/worktree:distribute` 테스트
- [ ] 새 skills 구조로 `/worktree:status` 테스트
- [ ] 새 skills 구조로 `/worktree:sync` 테스트
- [ ] install.sh 실행 후 skills 디렉토리 복사 확인
- [ ] 기존 commands 하위 호환성 확인

## Related Issues

- Epic: #24
- Phase 1 Issue: #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 설치 과정에서 스킬(extensions) 디렉토리를 옵션으로 자동 복사하여 구성에 포함하는 설치 지원 추가
  * Git 워크트리 관리용 스킬(계획·분배·상태·동기화) 및 사용 가이드와 워크플로우 문서 추가

* **지원 중단**
  * 기존 워크트리 명령/에이전트 문서에 대해 스킬 기반 워크플로우로의 마이그레이션 및 사용 중단 안내 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->